### PR TITLE
Check duration keys before ending session

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ enable-singleclick: false
 enable-woodway: false
 first-time: true
 fps: 8
-logs-dir: C:\cometrics\1.3.6\logs
+logs-dir: C:\cometrics\1.3.7\logs
 patient-concerns: concerns.yml
 phases:
 - Assessment

--- a/output_view_ui.py
+++ b/output_view_ui.py
@@ -198,7 +198,9 @@ class OutputViewPanel:
         if self.video_view.player:
             self.video_view.video_slider.config(state='disabled')
 
-    def stop_session(self):
+    def stop_session(self, final_time):
+        if self.key_view:
+            self.check_duration_keys(final_time)
         if self.e4_view:
             self.e4_view.session_started = False
             self.e4_view.streaming = False
@@ -237,6 +239,11 @@ class OutputViewPanel:
                 self.video_view.add_event(key_events)
             else:
                 print("INFO: No key events returned")
+
+    def check_duration_keys(self, final_time):
+        for i in range(0, len(self.key_view.dur_bindings)):
+            if self.key_view.dur_sticky[i]:
+                self.check_event(self.key_view.dur_bindings[i][0], final_time)
 
     def delete_last_event(self):
         self.key_view.delete_last_event()

--- a/session_manager_ui.py
+++ b/session_manager_ui.py
@@ -439,7 +439,7 @@ class SessionManagerWindow:
 
     def stop_session(self):
         self.stf.stop_session()
-        self.ovu.stop_session()
+        self.ovu.stop_session(self.stf.session_time)
         self.save_session()
         self.listener.stop()
 

--- a/ui_params.py
+++ b/ui_params.py
@@ -1,4 +1,4 @@
-cometrics_version = "1.3.6"
+cometrics_version = "1.3.7"
 ui_title = f"cometrics v{cometrics_version}"
 
 cometrics_data_root = fr'C:\cometrics'


### PR DESCRIPTION
- Duration keys are checked and unstickied at end of session
- Bump patch number
- Closes #35 